### PR TITLE
Add status of collected act 4 keys to state response

### DIFF
--- a/src/main/java/communicationmod/GameStateConverter.java
+++ b/src/main/java/communicationmod/GameStateConverter.java
@@ -85,6 +85,7 @@ public class GameStateConverter {
      * - "deck" (list): A list of the cards in the player's deck
      * - "potions" (list): A list of the player's potions (empty slots are PotionSlots)
      * - "map" (list): The current dungeon map
+     * - "keys" (object): Contains booleans for each of the three keys to reach Act 4
      * Sometimes present:
      * - "current_action" (list): The class name of the action in the action manager queue, if not empty
      * - "combat_state" (list): The state of the combat (draw pile, monsters, etc.)
@@ -142,6 +143,13 @@ public class GameStateConverter {
             state.put("combat_state", getCombatState());
         }
         state.put("screen_state", getScreenState());
+
+        HashMap<String, Boolean> keys = new HashMap<>();
+        keys.put("ruby", Settings.hasRubyKey);
+        keys.put("emerald", Settings.hasEmeraldKey);
+        keys.put("sapphire", Settings.hasSapphireKey);
+        state.put("keys", keys);
+
         return state;
     }
 


### PR DESCRIPTION
Add a "keys" section to the "game_state" response with boolean indicators of whether the ruby, sapphire, and emerald keys have been collected. The section is always present, even in games where the keys are not available to be collected (in which case the booleans will always be false).