### PR TITLE
Allow shop 'combat' rewards like cauldron to be skipped

### DIFF
--- a/src/main/java/communicationmod/ChoiceScreenUtils.java
+++ b/src/main/java/communicationmod/ChoiceScreenUtils.java
@@ -212,7 +212,7 @@ public class ChoiceScreenUtils {
             case CARD_REWARD:
                 return isCardRewardSkipAvailable();
             case COMBAT_REWARD:
-                return false;
+                return isCombatRewardCloseAvailable();
             case MAP:
                 return AbstractDungeon.dungeonMapScreen.dismissable;
             case BOSS_REWARD:
@@ -240,6 +240,8 @@ public class ChoiceScreenUtils {
         switch (choiceType) {
             case CARD_REWARD:
                 return "skip";
+            case COMBAT_REWARD:
+                return "skip";
             case MAP:
                 return "return";
             case BOSS_REWARD:
@@ -260,6 +262,7 @@ public class ChoiceScreenUtils {
     private static void pressCancelButton(ChoiceType choiceType) {
         switch (choiceType) {
             case CARD_REWARD:
+            case COMBAT_REWARD:
                 AbstractDungeon.closeCurrentScreen();
                 return;
             case MAP:
@@ -396,6 +399,11 @@ public class ChoiceScreenUtils {
     public static boolean isCardRewardSkipAvailable() {
         SkipCardButton skipButton = (SkipCardButton) ReflectionHacks.getPrivate(AbstractDungeon.cardRewardScreen, CardRewardScreen.class, "skipButton");
         return !((boolean) ReflectionHacks.getPrivate(skipButton, SkipCardButton.class, "isHidden"));
+    }
+
+    public static boolean isCombatRewardCloseAvailable() {
+        CancelButton cancelButton = AbstractDungeon.overlayMenu.cancelButton;
+        return !cancelButton.isHidden;
     }
 
     public static void makeCardRewardChoice(int choice) {


### PR DESCRIPTION
While normal combat rewards don't have a skip/cancel button, the combat reward UI is reused for certain out-of-combat rewards, such as the potion rewards for the cauldron relic, or the card rewards for the orrery relic (both shop relics). These rewards can be skipped, i.e. there is a "close" button on the bottom left of the screen. Proceeding is not equivalent to skipping because it's interpreted as exiting the shop, rather than closing the reward UI. Without the ability to close the reward UI, nothing else can be purchased from the shop.

This PR checks for the presence of a skip (technically "close") button when in the `COMBAT_REWARD` screen type, and allows the SKIP command if the button is visible.  