### PR TITLE
add emerald key node information to map state screen

### DIFF
--- a/src/main/java/communicationmod/ChoiceScreenUtils.java
+++ b/src/main/java/communicationmod/ChoiceScreenUtils.java
@@ -683,6 +683,24 @@ public class ChoiceScreenUtils {
         return (currMapNode.y == 14 || (AbstractDungeon.id.equals(TheEnding.ID) && currMapNode.y == 2));
     }
 
+    /**
+     * Return the room with the emeraldKey containing a "flame elite".
+     * @return MapRoomNode|null The map screen state object
+     */
+    public static MapRoomNode findEmeraldKeyNode() {
+        ArrayList<ArrayList<MapRoomNode>> map = AbstractDungeon.map;
+
+        for (ArrayList<MapRoomNode> layer : map) {
+            for (MapRoomNode node : layer) {
+                if (node.hasEmeraldKey) {
+                    return node;
+                }
+            }
+        }
+
+        return null;
+    }
+
     public static ArrayList<String> getMapScreenChoices() {
         ArrayList<String> choices = new ArrayList<>();
         MapRoomNode currMapNode = AbstractDungeon.getCurrMapNode();

--- a/src/main/java/communicationmod/GameStateConverter.java
+++ b/src/main/java/communicationmod/GameStateConverter.java
@@ -299,6 +299,7 @@ public class GameStateConverter {
     /**
      * The map screen state object contains:
      * "current_node" (object): The node object for the currently selected node, if applicable
+     * "emerald_key_node" (object): The node object for the emerald key node, if available
      * "next_nodes" (list): A list of nodes that can be chosen next
      * "first_node_chosen" (boolean): Whether the first node in the act has already been chosen
      * "boss_available" (boolean): Whether the next node choice is a boss
@@ -308,6 +309,10 @@ public class GameStateConverter {
         HashMap<String, Object> state = new HashMap<>();
         if (AbstractDungeon.getCurrMapNode() != null) {
             state.put("current_node", convertMapRoomNodeToJson(AbstractDungeon.getCurrMapNode()));
+        }
+        final MapRoomNode emeraldKeyNode = ChoiceScreenUtils.findEmeraldKeyNode();
+        if (emeraldKeyNode != null) {
+            state.put("emerald_key_node", convertMapRoomNodeToJson(emeraldKeyNode));
         }
         ArrayList<Object> nextNodesJson = new ArrayList<>();
         for(MapRoomNode node : ChoiceScreenUtils.getMapScreenNodeChoices()) {


### PR DESCRIPTION
This way we can react on the flame-elite to chase the emerald key.

This helps the guys over at https://github.com/xaved88/bottled_ai/ with their bot and beating the final boss.