### PR TITLE
Add 'abandon' command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>autoplay</groupId>
     <artifactId>CommunicationMod</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <packaging>jar</packaging>
     <name>Communication Mod</name>
     <description>Used to help external programs communicate with Slay the Spire</description>
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.2</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <id>CommunicationMod</id>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>autoplay</groupId>
     <artifactId>CommunicationMod</artifactId>
-    <version>1.2.2</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
     <name>Communication Mod</name>
     <description>Used to help external programs communicate with Slay the Spire</description>
@@ -53,7 +53,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.6.2</version>
                 <executions>
                     <execution>
                         <id>CommunicationMod</id>

--- a/src/main/java/communicationmod/CommandExecutor.java
+++ b/src/main/java/communicationmod/CommandExecutor.java
@@ -20,6 +20,7 @@ import com.megacrit.cardcrawl.potions.PotionSlot;
 import com.megacrit.cardcrawl.random.Random;
 import com.megacrit.cardcrawl.relics.AbstractRelic;
 import com.megacrit.cardcrawl.rooms.*;
+import com.megacrit.cardcrawl.screens.DeathScreen;
 import communicationmod.patches.InputActionPatch;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/communicationmod/CommandExecutor.java
+++ b/src/main/java/communicationmod/CommandExecutor.java
@@ -124,7 +124,7 @@ public class CommandExecutor {
 
     private static void executeAbandonCommand() throws InvalidCommandException {
         if (!isInDungeon()) {
-            throw new InvalidCommandException("Cannot abandon run: not currently in a dungeon.");
+            throw new InvalidCommandException("Cannot abandon run: not currently in a run.");
         }
         AbstractDungeon.closeCurrentScreen();
         AbstractDungeon.player.isDead = true;

--- a/src/main/java/communicationmod/CommandExecutor.java
+++ b/src/main/java/communicationmod/CommandExecutor.java
@@ -78,6 +78,9 @@ public class CommandExecutor {
             case "wait":
                 executeWaitCommand(tokens);
                 return true;
+            case "abandon":
+                executeAbandonCommand();
+                return true;
 
             default:
                 logger.info("This should never happen.");
@@ -112,10 +115,22 @@ public class CommandExecutor {
             availableCommands.add("key");
             availableCommands.add("click");
             availableCommands.add("wait");
+            availableCommands.add("abandon");
         }
         availableCommands.add("state");
         return availableCommands;
     }
+
+    private static void executeAbandonCommand() throws InvalidCommandException {
+        if (!isInDungeon()) {
+            throw new InvalidCommandException("Cannot abandon run: not currently in a dungeon.");
+        }
+        AbstractDungeon.closeCurrentScreen();
+        AbstractDungeon.player.isDead = true;
+        AbstractDungeon.deathScreen = new DeathScreen(AbstractDungeon.getMonsters());
+        CommunicationMod.mustSendGameState = true;
+    }
+
 
     public static boolean isCommandAvailable(String command) {
         if(command.equals("confirm") || command.equalsIgnoreCase("proceed")) {


### PR DESCRIPTION
Add an 'abandon' command, that abandons the current run. The way to do this before was to use the 'click' command multiple times (open settings -> abandon -> confirm).

DISCLAIMER: These changes were made by generative AI, but I have reviewed, tested and revised them, and it's quite a small change. The actual code to abandon the run was taken from the Slay the Spire source code. AI was mostly used to figure out where to place it and how to connect it to the command system. I understand if this means the pull request will be rejected.